### PR TITLE
Passing state via Prop Drilling

### DIFF
--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -2,12 +2,20 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Styles from "./PokemonCard.styled";
 
-export const PokemonCard = ({ id, name, image }) => {
+export const PokemonCard = ({ id, name, image, state, dispatch }) => {
     const navigate = useNavigate();
 
-    const onAdd = useCallback((e) => {
-        e.stopPropagation();
-    }, []);
+    const onAdd = useCallback(
+        (e) => {
+            e.stopPropagation();
+            try {
+                dispatch({ type: "TOGGLE", payload: { id } });
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [dispatch, id],
+    );
 
     return (
         <Styles.Container onClick={() => navigate(`/dex/${id}`)}>
@@ -18,7 +26,9 @@ export const PokemonCard = ({ id, name, image }) => {
                 <Styles.Index>No. {Number(id).toString().padStart(3, "0")}</Styles.Index>
             </Styles.Info>
 
-            <Styles.Button onClick={onAdd}>추가</Styles.Button>
+            <Styles.Button onClick={onAdd}>
+                {state.selectedPokemonIds.includes(id) ? "삭제" : "추가"}
+            </Styles.Button>
         </Styles.Container>
     );
 };

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -1,8 +1,8 @@
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Styles from "./PokemonCard.styled";
 
-export const PokemonCard = ({ id, name, image, state, dispatch }) => {
+export const PokemonCard = memo(({ id, name, image, isSelected, dispatch }) => {
     const navigate = useNavigate();
 
     const onAdd = useCallback(
@@ -26,9 +26,9 @@ export const PokemonCard = ({ id, name, image, state, dispatch }) => {
                 <Styles.Index>No. {Number(id).toString().padStart(3, "0")}</Styles.Index>
             </Styles.Info>
 
-            <Styles.Button onClick={onAdd}>
-                {state.selectedPokemonIds.includes(id) ? "삭제" : "추가"}
-            </Styles.Button>
+            <Styles.Button onClick={onAdd}>{isSelected ? "삭제" : "추가"}</Styles.Button>
         </Styles.Container>
     );
-};
+});
+
+PokemonCard.displayName = "PokemonCard";

--- a/src/components/PokemonDashboard.jsx
+++ b/src/components/PokemonDashboard.jsx
@@ -1,9 +1,10 @@
+import { memo } from "react";
 import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonCardPlaceholder } from "@/components/PokemonCardPlaceholder";
 import * as Styles from "./PokemonDashboard.styled";
 import { pokemonData } from "@/__mocks__";
 
-export const PokemonDashboard = ({ state, dispatch }) => {
+export const PokemonDashboard = memo(({ state, dispatch }) => {
     return (
         <Styles.Container>
             <Styles.Content>
@@ -14,7 +15,7 @@ export const PokemonDashboard = ({ state, dispatch }) => {
                             id={id}
                             name={pokemonData[id - 1].korean_name}
                             image={pokemonData[id - 1].img_url}
-                            state={state}
+                            isSelected={true}
                             dispatch={dispatch}
                         />
                     );
@@ -25,4 +26,6 @@ export const PokemonDashboard = ({ state, dispatch }) => {
             </Styles.Content>
         </Styles.Container>
     );
-};
+});
+
+PokemonDashboard.displayName = "PokemonDashboard";

--- a/src/components/PokemonDashboard.jsx
+++ b/src/components/PokemonDashboard.jsx
@@ -1,13 +1,27 @@
+import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonCardPlaceholder } from "@/components/PokemonCardPlaceholder";
 import * as Styles from "./PokemonDashboard.styled";
+import { pokemonData } from "@/__mocks__";
 
-export const PokemonDashboard = () => {
+export const PokemonDashboard = ({ state, dispatch }) => {
     return (
         <Styles.Container>
             <Styles.Content>
-                {Array.from({ length: 6 }).map((_, index) => (
-                    <PokemonCardPlaceholder key={index} />
-                ))}
+                {state.selectedPokemonIds.map((id) => {
+                    return (
+                        <PokemonCard
+                            key={id}
+                            id={id}
+                            name={pokemonData[id - 1].korean_name}
+                            image={pokemonData[id - 1].img_url}
+                            state={state}
+                            dispatch={dispatch}
+                        />
+                    );
+                })}
+                {Array.from({ length: 6 - state.selectedPokemonIds.length }).map((_, index) => {
+                    return <PokemonCardPlaceholder key={index} />;
+                })}
             </Styles.Content>
         </Styles.Container>
     );

--- a/src/hooks/usePokemon.js
+++ b/src/hooks/usePokemon.js
@@ -1,4 +1,4 @@
-import { useReducer } from "react";
+import { useCallback, useReducer } from "react";
 
 export const POKEMON_LIMIT = 6;
 
@@ -38,20 +38,24 @@ const reducer = (state, action) => {
 export const usePokemon = () => {
     const [state, _dispatch] = useReducer(reducer, initialState);
 
-    const dispatch = (action) => {
-        const { id } = action.payload || {};
+    const dispatch = useCallback(
+        (action) => {
+            const { id } = action.payload || {};
 
-        if (action.type === "TOGGLE" && !state.selectedPokemonIds.includes(id)) {
-            if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
-                throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
-        }
-        if (action.type === "APPEND") {
-            if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
-                throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
-        }
+            if (action.type === "TOGGLE" && !state.selectedPokemonIds.includes(id)) {
+                if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+                    throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
+            }
+            if (action.type === "APPEND") {
+                if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+                    throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
+            }
 
-        _dispatch(action);
-    };
+            _dispatch(action);
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [_dispatch],
+    );
 
     return {
         state,

--- a/src/hooks/usePokemon.js
+++ b/src/hooks/usePokemon.js
@@ -1,0 +1,60 @@
+import { useReducer } from "react";
+
+export const POKEMON_LIMIT = 6;
+
+const initialState = {
+    selectedPokemonIds: [],
+};
+
+const reducer = (state, action) => {
+    const { id } = action.payload;
+    const isSelected = state.selectedPokemonIds.includes(id);
+
+    switch (action.type) {
+        case "APPEND":
+            return {
+                ...state,
+                selectedPokemonIds: [...state.selectedPokemonIds, id],
+            };
+        case "REMOVE":
+            return {
+                ...state,
+                selectedPokemonIds: state.selectedPokemonIds.filter(
+                    (pokemonId) => pokemonId !== id,
+                ),
+            };
+        case "TOGGLE":
+            return {
+                ...state,
+                selectedPokemonIds: isSelected
+                    ? state.selectedPokemonIds.filter((pokemonId) => pokemonId !== id)
+                    : [...state.selectedPokemonIds, id],
+            };
+        default:
+            return state;
+    }
+};
+
+export const usePokemon = () => {
+    const [state, _dispatch] = useReducer(reducer, initialState);
+
+    const dispatch = (action) => {
+        const { id } = action.payload || {};
+
+        if (action.type === "TOGGLE" && !state.selectedPokemonIds.includes(id)) {
+            if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+                throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
+        }
+        if (action.type === "APPEND") {
+            if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+                throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
+        }
+
+        _dispatch(action);
+    };
+
+    return {
+        state,
+        dispatch,
+    };
+};

--- a/src/pages/PokemonListPage.jsx
+++ b/src/pages/PokemonListPage.jsx
@@ -1,12 +1,15 @@
 import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonDashboard } from "@/components/PokemonDashboard";
+import { usePokemon } from "@/hooks/usePokemon";
 import * as Styles from "./PokemonListPage.styled";
 import { pokemonData } from "@/__mocks__";
 
 export const PokemonListPage = () => {
+    const { state, dispatch } = usePokemon();
+
     return (
         <Styles.PageContainer>
-            <PokemonDashboard></PokemonDashboard>
+            <PokemonDashboard state={state} dispatch={dispatch} />
 
             <Styles.PokemonList>
                 {pokemonData.map((pokemon) => {
@@ -16,6 +19,8 @@ export const PokemonListPage = () => {
                             id={pokemon.id}
                             name={pokemon.korean_name}
                             image={pokemon.img_url}
+                            state={state}
+                            dispatch={dispatch}
                         />
                     );
                 })}

--- a/src/pages/PokemonListPage.jsx
+++ b/src/pages/PokemonListPage.jsx
@@ -13,13 +13,15 @@ export const PokemonListPage = () => {
 
             <Styles.PokemonList>
                 {pokemonData.map((pokemon) => {
+                    const isSelected = state.selectedPokemonIds.includes(pokemon.id);
+
                     return (
                         <PokemonCard
                             key={pokemon.id}
                             id={pokemon.id}
                             name={pokemon.korean_name}
                             image={pokemon.img_url}
-                            state={state}
+                            isSelected={isSelected}
                             dispatch={dispatch}
                         />
                     );


### PR DESCRIPTION
- prop drilling 을 통해서 상태전달하였으나, `state.selectedPokemonIds` 상태가 변경될 때 마다 Card, Dashboard 컴포넌트가 모두 재렌더링됨
  - 해당 state 를 prop 으로 받는데 상태 변경시 state 를 prop 으로 받는 모든 컴포넌트가 재렌더링 되기 때문임
  - (A) 컴포넌트의 state 가 변경되거나, (B) 부모컴포넌트가 재렌더링될때, (C) props 가 변경될때, (D) forceUpdate 가 호출될때 재렌더링됨
  - (A), (C) 로 인해서 props 로 state 를 받는 컴포넌트가 재렌더링됨



- 재렌더링 방지를 위해
  - `usePokemon` 훅에서 `dispatch` 함수를 재생성하지 않도록 `useCallback` 으로 감싼다
  - `PokemonCard` 및 `PokemonDashboard` 컴포넌트를 `memo` 고차컴포넌트로 감싸서 props 가 변경되었을때만 재렌더링되도록 변경한다
  - `PokemonCard` 컴포넌트에서 `state.selectedPokemonIds` 배열 (객체값)을 받는것이 아닌, `isSelected` (원시값)을 받는다
    - React 는 내부적으로 얕은 비교 (level 1 까지 비교) 를 통해 재렌더링 여부를 확인한다


| 최적화 이전 | 최적화 이후|
| --- | --- |
| <img width="420" alt="image" src="https://github.com/user-attachments/assets/2fe5eed4-f1c1-4d79-a7a3-514ce6b666b3" /> | <img width="420" alt="image" src="https://github.com/user-attachments/assets/89aa890c-dff2-4b90-94db-da7f1e2b5f75" />|



