### PR TITLE
Passing state via Context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,15 @@ import { Fragment } from "react";
 import { RouterProvider } from "react-router-dom";
 import { router } from "@/app/router";
 import { GlobalStyles } from "@/app/styles/GlobalStyles";
+import { PokemonContextProvider } from "@/contexts/PokemonContext";
 
 export default function App() {
     return (
         <Fragment>
-            <GlobalStyles />
-            <RouterProvider router={router} />
+            <PokemonContextProvider>
+                <GlobalStyles />
+                <RouterProvider router={router} />
+            </PokemonContextProvider>
         </Fragment>
     );
 }

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -1,9 +1,12 @@
 import { memo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Styles from "./PokemonCard.styled";
+import { usePokemonContext } from "@/contexts/PokemonContext";
 
-export const PokemonCard = memo(({ id, name, image, isSelected, dispatch }) => {
+export const PokemonCard = memo(({ id, name, image, isSelected }) => {
     const navigate = useNavigate();
+
+    const { dispatch } = usePokemonContext();
 
     const onAdd = useCallback(
         (e) => {

--- a/src/components/PokemonCard.jsx
+++ b/src/components/PokemonCard.jsx
@@ -1,12 +1,12 @@
 import { memo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import * as Styles from "./PokemonCard.styled";
-import { usePokemonContext } from "@/contexts/PokemonContext";
+import { usePokemonDispatch } from "@/contexts/PokemonContext";
 
 export const PokemonCard = memo(({ id, name, image, isSelected }) => {
     const navigate = useNavigate();
 
-    const { dispatch } = usePokemonContext();
+    const dispatch = usePokemonDispatch();
 
     const onAdd = useCallback(
         (e) => {

--- a/src/components/PokemonDashboard.jsx
+++ b/src/components/PokemonDashboard.jsx
@@ -3,8 +3,11 @@ import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonCardPlaceholder } from "@/components/PokemonCardPlaceholder";
 import * as Styles from "./PokemonDashboard.styled";
 import { pokemonData } from "@/__mocks__";
+import { usePokemonContext } from "@/contexts/PokemonContext";
 
-export const PokemonDashboard = memo(({ state, dispatch }) => {
+export const PokemonDashboard = memo(() => {
+    const { state } = usePokemonContext();
+
     return (
         <Styles.Container>
             <Styles.Content>
@@ -16,7 +19,6 @@ export const PokemonDashboard = memo(({ state, dispatch }) => {
                             name={pokemonData[id - 1].korean_name}
                             image={pokemonData[id - 1].img_url}
                             isSelected={true}
-                            dispatch={dispatch}
                         />
                     );
                 })}

--- a/src/components/PokemonDashboard.jsx
+++ b/src/components/PokemonDashboard.jsx
@@ -3,10 +3,10 @@ import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonCardPlaceholder } from "@/components/PokemonCardPlaceholder";
 import * as Styles from "./PokemonDashboard.styled";
 import { pokemonData } from "@/__mocks__";
-import { usePokemonContext } from "@/contexts/PokemonContext";
+import { usePokemonState } from "@/contexts/PokemonContext";
 
 export const PokemonDashboard = memo(() => {
-    const { state } = usePokemonContext();
+    const state = usePokemonState();
 
     return (
         <Styles.Container>

--- a/src/contexts/PokemonContext.jsx
+++ b/src/contexts/PokemonContext.jsx
@@ -1,27 +1,33 @@
-import { createContext, useContext, useMemo } from "react";
+import { createContext, useContext } from "react";
 import { usePokemon } from "@/hooks/usePokemon";
 
-export const PokemonContext = createContext(null);
+export const PokemonStateContext = createContext(null);
+export const PokemonDispatchContext = createContext(null);
 
 export const PokemonContextProvider = ({ children }) => {
     const { state, dispatch } = usePokemon();
 
     return (
-        <PokemonContext.Provider
-            value={{
-                state,
-                dispatch,
-            }}
-        >
-            {children}
-        </PokemonContext.Provider>
+        <PokemonStateContext.Provider value={state}>
+            <PokemonDispatchContext.Provider value={dispatch}>
+                {children}
+            </PokemonDispatchContext.Provider>
+        </PokemonStateContext.Provider>
     );
 };
 
-export const usePokemonContext = () => {
-    const context = useContext(PokemonContext);
-    if (!context)
-        throw new Error("usePokemonContext 는 PokemonContextProvider 내부에서 호출해야 합니다.");
+export const usePokemonState = () => {
+    const context = useContext(PokemonStateContext);
+    if (!context) {
+        throw new Error("usePokemonState는 PokemonContextProvider 내부에서 호출해야 합니다.");
+    }
+    return context;
+};
 
-    return useMemo(() => context, [context]);
+export const usePokemonDispatch = () => {
+    const context = useContext(PokemonDispatchContext);
+    if (!context) {
+        throw new Error("usePokemonDispatch는 PokemonContextProvider 내부에서 호출해야 합니다.");
+    }
+    return context;
 };

--- a/src/contexts/PokemonContext.jsx
+++ b/src/contexts/PokemonContext.jsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useMemo } from "react";
+import { usePokemon } from "@/hooks/usePokemon";
+
+export const PokemonContext = createContext(null);
+
+export const PokemonContextProvider = ({ children }) => {
+    const { state, dispatch } = usePokemon();
+
+    return (
+        <PokemonContext.Provider
+            value={{
+                state,
+                dispatch,
+            }}
+        >
+            {children}
+        </PokemonContext.Provider>
+    );
+};
+
+export const usePokemonContext = () => {
+    const context = useContext(PokemonContext);
+    if (!context)
+        throw new Error("usePokemonContext 는 PokemonContextProvider 내부에서 호출해야 합니다.");
+
+    return useMemo(() => context, [context]);
+};

--- a/src/pages/PokemonListPage.jsx
+++ b/src/pages/PokemonListPage.jsx
@@ -2,10 +2,11 @@ import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonDashboard } from "@/components/PokemonDashboard";
 import * as Styles from "./PokemonListPage.styled";
 import { pokemonData } from "@/__mocks__";
-import { usePokemonContext } from "@/contexts/PokemonContext";
+import { usePokemonDispatch, usePokemonState } from "@/contexts/PokemonContext";
 
 export const PokemonListPage = () => {
-    const { state, dispatch } = usePokemonContext();
+    const state = usePokemonState();
+    const dispatch = usePokemonDispatch();
 
     return (
         <Styles.PageContainer>

--- a/src/pages/PokemonListPage.jsx
+++ b/src/pages/PokemonListPage.jsx
@@ -1,15 +1,15 @@
 import { PokemonCard } from "@/components/PokemonCard";
 import { PokemonDashboard } from "@/components/PokemonDashboard";
-import { usePokemon } from "@/hooks/usePokemon";
 import * as Styles from "./PokemonListPage.styled";
 import { pokemonData } from "@/__mocks__";
+import { usePokemonContext } from "@/contexts/PokemonContext";
 
 export const PokemonListPage = () => {
-    const { state, dispatch } = usePokemon();
+    const { state, dispatch } = usePokemonContext();
 
     return (
         <Styles.PageContainer>
-            <PokemonDashboard state={state} dispatch={dispatch} />
+            <PokemonDashboard />
 
             <Styles.PokemonList>
                 {pokemonData.map((pokemon) => {


### PR DESCRIPTION
- context 로 state 전달
  - 단일 context api 사용시 value 객체 `{state, dispatch}` 는 state 변경시 새로운 참조 갖음
  - 이때문에 context 구독하는 모든 컴포넌트는 state 변경시 재렌더링
  - 특히 `PokemonCard` 컴포넌트는 dispatch 만 사용함에도 state 변경에 의해 재렌더링 됨

- 단일 context 를 `PokemonStateContext` , `PokemonDispatchContext` 로 분리
  - `PokemonCard` 는 dispatch 만 구독하므로 기존처럼 state 가 변경되서 context.value 가 변경되더라도 재렌더링 방지됨

| 전 | 후 |
|---|---|
|<img width="429" alt="image" src="https://github.com/user-attachments/assets/24704958-cc83-4a65-8e73-158d66b7f4eb" /> | <img width="429" alt="image" src="https://github.com/user-attachments/assets/e42de88a-4329-4ba8-ab18-8d7cbc38834e" />|