### PR TITLE
fix: use useRef for selectedPokemonIds to optimize state management

### DIFF
--- a/src/hooks/usePokemon.js
+++ b/src/hooks/usePokemon.js
@@ -1,4 +1,4 @@
-import { useCallback, useReducer } from "react";
+import { useCallback, useReducer, useRef } from "react";
 
 export const POKEMON_LIMIT = 6;
 
@@ -37,23 +37,27 @@ const reducer = (state, action) => {
 
 export const usePokemon = () => {
     const [state, _dispatch] = useReducer(reducer, initialState);
+    const selectedPokemonIdsRef = useRef(state.selectedPokemonIds);
+
+    selectedPokemonIdsRef.current = state.selectedPokemonIds;
 
     const dispatch = useCallback(
         (action) => {
             const { id } = action.payload || {};
 
-            if (action.type === "TOGGLE" && !state.selectedPokemonIds.includes(id)) {
-                if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+            const currentSelectedIds = selectedPokemonIdsRef.current;
+
+            if (action.type === "TOGGLE" && !currentSelectedIds.includes(id)) {
+                if (currentSelectedIds.length >= POKEMON_LIMIT)
                     throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
             }
             if (action.type === "APPEND") {
-                if (state.selectedPokemonIds.length >= POKEMON_LIMIT)
+                if (currentSelectedIds.length >= POKEMON_LIMIT)
                     throw new Error(`포켓몬은 ${POKEMON_LIMIT}마리까지만 선택할 수 있습니다!`);
             }
 
             _dispatch(action);
         },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         [_dispatch],
     );
 


### PR DESCRIPTION
- #4 

- `usePokemon` 훅의 useCallback 의존성 배열 `selectedPokemonIds` 를 누락하여 `POKEMON_LIMITS` 를 넘어서더라도 예외를 발생하지 않는 문제 발생
  - dispatch 함수에서 접근하는 `state.selectedPokemonIds` 는 useCallback 이 처음 생성시 클로저로 기억하고 있는 stale 한 값을 가지고 있기 때문

- 이를 해결하기 위해 의존성 배열에 `state.selectedPokemonIds` 를 넣으면 `dispatch` 가 항상 재생성되어 컴포넌트가 재렌더링됨
  - 상태값을 저장하는 ref 를 만들고, 재렌더링시마다 `state.selectedPokemonIds` 로 최신화
  - `useCallback` 에서는 해당 ref 를 참조하여 상태가 아닌 ref 값에 의해서 유지되므로 함수가 재생성되지 않음